### PR TITLE
Replace deprecated usage of fs.rmdir

### DIFF
--- a/bin/scriptimate.js
+++ b/bin/scriptimate.js
@@ -541,7 +541,7 @@ const runGeneration = async (lang) => {
     }
   }
 
-  await fs.rmdir(FRAMES_DIR, { recursive: true });
+  await fs.rm(FRAMES_DIR, { recursive: true });
   await fs.mkdir(FRAMES_DIR, { recursive: true });
 
   const processed_lines = []


### PR DESCRIPTION
This is causing a node deprecation warning to show up in the tool output:

```console
(node:1) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```

The warning provides the recommended fix.

Resolves #4